### PR TITLE
Fix virtual filesystem for wasmer runnables

### DIFF
--- a/src/runnables/EmscriptenRunnable.js
+++ b/src/runnables/EmscriptenRunnable.js
@@ -174,13 +174,9 @@ class EmscrWasmRunnable {
 
   /* file handling */
 
-  _readFilesFromFS(
-    instance,
-    directory = "/",
-    includeBinary = true,
-    filesToIgnore = []
-  ) {
+  _readFilesFromFS(instance, directory = "/", includeBinary = true) {
     const path = instance.FS.lookupPath(directory)
+
     const getFilesFromNode = (parentNode) => {
       let files = []
       Object.values(parentNode.contents).forEach((node) => {
@@ -198,19 +194,24 @@ class EmscrWasmRunnable {
       })
       return files
     }
+
     let files = getFilesFromNode(path.node)
-    if (filesToIgnore.length > 0)
-      files = files.filter((file) => {
-        return filesToIgnore.some((ignofile) => ignofile.name != file.name)
-      })
     return files
   }
 
   _writeFilesToFS(instance, files = []) {
     files.forEach((file) => {
       try {
-        if (file.bytes instanceof Uint8Array)
+        if (file.bytes instanceof Uint8Array) {
           instance.FS.writeFile(file.name, file.bytes)
+
+          const timestamp =
+            file.timestamp instanceof Date
+              ? file.timestamp.getTime()
+              : file.timestamp
+          if (typeof timestamp === "number")
+            instance.FS.utime(file.name, timestamp, timestamp)
+        }
       } catch (e) {
         console.error(e.name + ": " + e.message)
       }

--- a/src/runnables/WasmerRunnable.js
+++ b/src/runnables/WasmerRunnable.js
@@ -2,6 +2,8 @@ import { WASI } from "@wasmer/wasi"
 import browserBindings from "@wasmer/wasi/lib/bindings/browser"
 import { WasmFs } from "@wasmer/wasmfs"
 
+const S_IFCHR = 8192 // magic constant from memFS
+
 class WasmerRunnable {
   /* method wrapper class for wasmer wasm modules.
     initializes memory filesystem and can execute wasm. */
@@ -102,6 +104,12 @@ class WasmerRunnable {
     const ttyFd = wasmFs.volume.openSync("/dev/tty", "w+")
     wasmFs.volume.fds[ttyFd].node.read = wasmFs.volume.fds[0].node.read
     wasmFs.volume.fds[ttyFd].node.write = wasmFs.volume.fds[1].node.write
+
+    // mark /dev/{stdin,stdout,stderr,tty} as character devices
+    wasmFs.volume.fds[0].node.setModeProperty(S_IFCHR)
+    wasmFs.volume.fds[1].node.setModeProperty(S_IFCHR)
+    wasmFs.volume.fds[2].node.setModeProperty(S_IFCHR)
+    wasmFs.volume.fds[ttyFd].node.setModeProperty(S_IFCHR)
 
     // create wasi runtime
     let wasi = new WASI({

--- a/src/runnables/WasmerRunnable.js
+++ b/src/runnables/WasmerRunnable.js
@@ -236,6 +236,15 @@ class WasmerRunnable {
           const path = file.name.split("/").slice(0, -1).join("/")
           wasmFs.fs.mkdirSync(path, { recursive: true })
           wasmFs.fs.writeFileSync(file.name, file.bytes)
+
+          if (file.timestamp instanceof Date)
+            wasmFs.fs.utimesSync(file.name, file.timestamp, file.timestamp)
+          else if (typeof file.timestamp === "number")
+            wasmFs.fs.utimesSync(
+              file.name,
+              file.timestamp / 1000,
+              file.timestamp / 1000
+            )
         }
       } catch (e) {
         console.error(e.name + ": " + e.message)


### PR DESCRIPTION
#### `wasmer` runnables

Instead of serializing the complete filesystem `volume` to JSON, read each file individually from the virtual filesystem using the `fs` API.

Fixes issues with corrupting binary files that aren't valid UTF-8, since the JSON serialization converted them to UTF-8 strings.

#### runnables (common)

Explicitly set file modification time when initializing the virtual filesystem of the runnables. This should keep modification times across multiple runnables (and between emscripten and wasmer).