### PR TITLE
Improve bundle size

### DIFF
--- a/src/WasmWebTerm.js
+++ b/src/WasmWebTerm.js
@@ -3,10 +3,14 @@ import { proxy, wrap } from "comlink"
 import { FitAddon } from "xterm-addon-fit"
 import XtermEchoAddon from "local-echo"
 import parse from "shell-quote/parse"
+import { inflate } from "pako" // fallback for DecompressionStream API (free as its used in WapmFetchUtil)
 
 import LineBuffer from "./LineBuffer"
 import WasmWorkerRAW from "./runners/WasmWorker" // will be prebuilt using webpack
-import { default as PromptsFallback } from "./runners/WasmRunner"
+import {
+  default as PromptsFallback,
+  MODULE_ID as WasmRunnerID, // get the id of this module in the final webpack bundle
+} from "./runners/WasmRunner"
 import WapmFetchUtil from "./WapmFetchUtil"
 
 class WasmWebTerm {
@@ -748,14 +752,71 @@ class WasmWebTerm {
       ) // 1000 chars buffer
 
       // create blob including webworker and its dependencies
-      const response = await fetch(WasmWorkerRAW)
-      const stream = response.body.pipeThrough(new DecompressionStream("gzip"))
-      const decompressed = new Response(stream, {
-        headers: { "Content-Type": "application/javascript" },
+      const workerSource = fetch(WasmWorkerRAW).then((response) => {
+        if ("DecompressionStream" in self) {
+          const stream = response.body.pipeThrough(
+            new DecompressionStream("gzip")
+          )
+          const decompressed = new Response(stream)
+          return decompressed.text()
+        } else {
+          return response.bytes().then((data) => inflate(data))
+        }
       })
-      const blob = await decompressed.blob()
 
-      // init webworker from blob (no separate file)
+      // HACK: Forward all modules for the `WasmRunner`(`PromptsFallback`) to the worker
+      //       instead of bundling them directly. This saves about 90 KiB by not serializing
+      //       these dependencies twice. This works fine, since we already use the identical
+      //       module already as a fallback.
+      const extraModules = {}
+      try {
+        const webpackModuleIds = Object.keys(__webpack_modules__)
+        let dependencies = [WasmRunnerID] // start with the `WasmRunner` module
+        for (
+          let dep = dependencies.shift();
+          dep != undefined;
+          dep = dependencies.shift()
+        ) {
+          // put the module into the list of modules to forward
+          const mod = __webpack_modules__[dep]
+          extraModules[dep] = mod
+
+          // parse module for imports of other module dependencies (like `r(MODULE_ID)`)
+          const matches = mod.toString().matchAll(/\br\((\d+)\)/g)
+          for (const match of matches) {
+            if (webpackModuleIds.includes(match[1])) dependencies.push(match[1])
+          }
+        }
+      } catch (err) {
+        // Could not collect the `WasmRunner` module and its dependencies for forwarding
+        console.error(
+          `Cannot collect the \`WasmRunner\` module and its dependencies for use in the Worker: ${err}`
+        )
+        console.error(
+          "Falling back to excuting `WasmRunner` in the PromptsFallback"
+        )
+
+        // -> use prompts as fallback
+        this._wasmRunner = new PromptsFallback()
+        this._worker = false
+        resolve(this._worker)
+
+        return
+      }
+
+      // prepend source of collected modules as well as the ID for the
+      // `WasmRunner` module to the original worker source
+      let prelude = "self._modules={"
+      for (const [id, module] of Object.entries(extraModules)) {
+        prelude += `${id}:${module.toString()},`
+      }
+      prelude += `};self.WasmRunnerID=${WasmRunnerID}\n`
+
+      const blob = new Blob([prelude, await workerSource], {
+        type: "application/javascript",
+      })
+
+      // init webworker from blob (no separate file, no cross-origin problems)
       this._workerRAW = new Worker(URL.createObjectURL(blob))
       const WasmWorker = wrap(this._workerRAW)
       this._worker = await new WasmWorker(this._pauseBuffer, this._stdinBuffer)

--- a/src/WasmWebTerm.js
+++ b/src/WasmWebTerm.js
@@ -748,7 +748,12 @@ class WasmWebTerm {
       ) // 1000 chars buffer
 
       // create blob including webworker and its dependencies
-      let blob = new Blob([WasmWorkerRAW], { type: "application/javascript" })
+      const response = await fetch(WasmWorkerRAW)
+      const stream = response.body.pipeThrough(new DecompressionStream("gzip"))
+      const decompressed = new Response(stream, {
+        headers: { "Content-Type": "application/javascript" },
+      })
+      const blob = await decompressed.blob()
 
       // init webworker from blob (no separate file)
       this._workerRAW = new Worker(URL.createObjectURL(blob))

--- a/src/runners/ImportInjectedModules.js
+++ b/src/runners/ImportInjectedModules.js
@@ -1,0 +1,13 @@
+// HACK: Inject all the modules that have been forward from the parent thread into
+//       our own bundle. This has to be done before importing any of these modules.
+const existingModules = Object.keys(__webpack_modules__)
+
+for (const [id, mod] of Object.entries(global._modules)) {
+  if (!existingModules.includes(id)) __webpack_modules__[id] = mod
+}
+
+// HACK: Make the lexicographic first export of the `WasmRunner` module available
+//       as the default export. Webpack does mangle/minify names longer than 2 characters.
+const WasmRunnerModule = __webpack_require__(global.WasmRunnerID)
+const defaultKey = Object.keys(WasmRunnerModule)[0]
+self.WasmRunner = WasmRunnerModule[defaultKey]

--- a/src/runners/WasmRunner.js
+++ b/src/runners/WasmRunner.js
@@ -213,3 +213,4 @@ class WasmRunner {
 }
 
 export default WasmRunner
+export const MODULE_ID = __webpack_module__.id

--- a/src/runners/WasmWorker.js
+++ b/src/runners/WasmWorker.js
@@ -1,4 +1,7 @@
 import { expose } from "comlink"
+// HACK: make `WasmRunner` and its dependecies available from the injected modules by the
+//       main thread, instead of importing and bundling them directly.
+import "./ImportInjectedModules"
 import WasmRunner from "./WasmRunner"
 
 class WasmWorker extends WasmRunner {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = {
     filename: "webterm.bundle.js",
     library: { type: "umd", name: "[name]" },
   },
+  optimization: {
+    moduleIds: "deterministic", // share deterministic ids with the worker bundle
+  },
   plugins: [
     new webpack.ProvidePlugin({
       Buffer: ["buffer", "Buffer"],

--- a/worker.loader.js
+++ b/worker.loader.js
@@ -37,6 +37,15 @@ module.exports = function (source) {
         name: "[name]",
       },
     },
+    optimization: {
+      moduleIds: "deterministic", // share deterministic ids with the main bundle
+    },
+    externals: {
+      // HACK: Do not bundle the `WasmRunner` module and its dependencies again.
+      //       Instead let the main thread forward it from its bundle when
+      //       instantiating the worker.
+      "./WasmRunner": "global WasmRunner",
+    },
     plugins: [
       new webpack.ProvidePlugin({
         Buffer: ["buffer", "Buffer"],


### PR DESCRIPTION
### Bundle compression

Use the ["new"](https://caniuse.com/?search=DecompressionStream) `CompressionStream` API to gzip-compress the embedded worker bundle. For compatibility the compressed data is stored in a base64-encoded `data:` URL. This is then decoded and decompressed before initializing the worker.


### Runtime injection of shared modules

Instead of including the `WasmRunner` module and its dependencies in the bundled worker source, mark it as `external` and inject the bundled `WasmRunner` module (with dependencies) of the main bundle when creating the worker.

This requires manually exporting the bundled source for these modules at runtime and putting them into the worker source. The worker will then inject these into its own bundled webpack modules before importing the `WasmRunner`. This drastically reduces the size of the embedded worker bundle while honestly being kind of a hack.

### Size improvements

| | Worker Size | Bundle Size |
|:---|---:|---:|
| Base | 247.3 KiB (100%) | 572 KiB (100%) |
| gzip compression | 96.3 KiB (38.9%) | 420 KiB (73.4%) |
| shared modules | 3.5 KiB (1.4%) | 328 KiB (57.3%) |